### PR TITLE
<html> conditional comments bug fix

### DIFF
--- a/Multiple linked stylesheets/index.html
+++ b/Multiple linked stylesheets/index.html
@@ -9,7 +9,7 @@ URL: http://stuffandnonsense.co.uk/projects/320andup
 
 <!--[if IEMobile 7 ]><html class="no-js iem7" manifest="default.appcache?v=1"><![endif]-->
 <!--[if lt IE 7 ]><html class="no-js ie6" lang="en"><![endif]-->
-<!--[if IE 7 ]><html class="no-js ie7" lang="en"><![endif]-->
+<!--[if (IE 7)&!(IEMobile) ]><html class="no-js ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="no-js ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7)|!(IEMobile)|!(IE)]><!--><html class="no-js" manifest="default.appcache?v=1" lang="en"><!--<![endif]-->
 

--- a/Single stylesheet/index.html
+++ b/Single stylesheet/index.html
@@ -9,7 +9,7 @@ URL: http://stuffandnonsense.co.uk/projects/320andup
 
 <!--[if IEMobile 7 ]><html class="no-js iem7" manifest="default.appcache?v=1"><![endif]-->
 <!--[if lt IE 7 ]><html class="no-js ie6" lang="en"><![endif]-->
-<!--[if IE 7 ]><html class="no-js ie7" lang="en"><![endif]-->
+<!--[if (IE 7)&!(IEMobile) ]><html class="no-js ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="no-js ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7)|!(IEMobile)|!(IE)]><!--><html class="no-js" manifest="default.appcache?v=1" lang="en"><!--<![endif]-->
 


### PR DESCRIPTION
Fixes a bug causing IE7 Mobile to receiving two < html > tags, one each for:
< !--[if IEMobile 7 ] >
< !--[if IE 7] >
