### PR TITLE
Correct media query for 600px

### DIFF
--- a/Multiple linked stylesheets/index.html
+++ b/Multiple linked stylesheets/index.html
@@ -33,7 +33,7 @@ License: http://creativecommons.org/licenses/MIT
 <link rel="stylesheet" media="print" href="css/print.css">
 <!-- For progressively larger displays -->
 <link rel="stylesheet" media="only screen and (min-width: 480px)" href="css/480.css">
-<link rel="stylesheet" media="only screen and (min-width: 480px)" href="css/600.css">
+<link rel="stylesheet" media="only screen and (min-width: 600px)" href="css/600.css">
 <link rel="stylesheet" media="only screen and (min-width: 768px)" href="css/768.css">
 <link rel="stylesheet" media="only screen and (min-width: 992px)" href="css/992.css">
 <!-- For Retina displays -->


### PR DESCRIPTION
Fixed the media query for 600px. It was set to 480px in the index.html for multiple linked stylesheets.
