### PR TITLE
Update jQuery to 1.7.1

### DIFF
--- a/Multiple linked stylesheets/404.html
+++ b/Multiple linked stylesheets/404.html
@@ -102,8 +102,10 @@ License: http://creativecommons.org/licenses/MIT
 <footer role="contentinfo" class="clearfix">
 </footer>
 
+<!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.1.min.js"><\/script>')</script>
 <!-- Scripts -->
-<script src="js/libs/jquery-1.6.2.min.js"></script>
 <script src="js/plugins.js"></script>
 <script src="js/script.js"></script>
 <script src="js/mylibs/helper.js"></script>

--- a/Multiple linked stylesheets/index.html
+++ b/Multiple linked stylesheets/index.html
@@ -89,8 +89,10 @@ License: http://creativecommons.org/licenses/MIT
 <footer role="contentinfo" class="clearfix">
 </footer>
 
+<!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.1.min.js"><\/script>')</script>
 <!-- Scripts -->
-<script src="js/libs/jquery-1.6.2.min.js"></script>
 <script src="js/plugins.js"></script>
 <script src="js/script.js"></script>
 <script src="js/mylibs/helper.js"></script>

--- a/Single stylesheet/404.html
+++ b/Single stylesheet/404.html
@@ -94,8 +94,10 @@ License: http://creativecommons.org/licenses/MIT/
 <footer role="contentinfo" class="clearfix">
 </footer>
 
+<!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.1.min.js"><\/script>')</script>
 <!-- Scripts -->
-<script src="js/libs/jquery-1.6.2.min.js"></script>
 <script src="js/plugins.js"></script>
 <script src="js/script.js"></script>
 <script src="js/mylibs/helper.js"></script>

--- a/Single stylesheet/index.html
+++ b/Single stylesheet/index.html
@@ -79,8 +79,10 @@ License: http://creativecommons.org/licenses/MIT/
 <footer role="contentinfo" class="clearfix">
 </footer>
 
+<!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.1.min.js"><\/script>')</script>
 <!-- Scripts -->
-<script src="js/libs/jquery-1.6.2.min.js"></script>
 <script src="js/plugins.js"></script>
 <script src="js/script.js"></script>
 <script src="js/mylibs/helper.js"></script>


### PR DESCRIPTION
Update jQuery to 1.7.1 and add link to Google CDN's jQuery, with a protocol relative URL, that will fall back to local if offline
