### PR TITLE
Error compiling style.less in multiple linked stylesheet

### DIFF
--- a/Multiple linked stylesheets/less/style.less
+++ b/Multiple linked stylesheets/less/style.less
@@ -299,7 +299,7 @@ button,
 input, 
 select, 
 textarea { 
-.font-size(12;
+.font-size(12);
 margin : 0; 
 vertical-align : baseline; 
 *vertical-align : middle; }
@@ -367,10 +367,10 @@ input[type="submit"] {
 -webkit-appearance : button; }
 
 ::-webkit-input-placeholder {
-.font-size(14; }
+.font-size(14); }
 
 input:-moz-placeholder { 
-.font-size(14; }
+.font-size(14); }
 
 .ie7 img,
 .iem7 img { 


### PR DESCRIPTION
When I compile the style.less file I get an error complaining about a missing }, but in reality it is three missing ) when using the font-size mixin.
