### PR TITLE
fixed quoting in .serif font-family

### DIFF
--- a/Single stylesheet/less/mixins.less
+++ b/Single stylesheet/less/mixins.less
@@ -63,7 +63,7 @@ font-size: ~"@{rem}rem"; }
 font-family : "Helvetica Neue", Helvetica, Arial, sans-serif; }
 
 .serif {
-font-family : "Cambria, Georgia, Times, "Times New Roman; }
+font-family : Cambria, Georgia, Times, "Times New Roman"; }
 
 .monospace {
 font-family : "Monaco", Courier New, monospace; }


### PR DESCRIPTION
The .serif mixin has some odd quoting in its font-family property.

I've made the quoting seem more reasonable as I can't think of a reason why it would be in the way it's currently defined.

Please educate me if I've changed something that is there for a reason!

Thanks,

Adam
