### PR TITLE
added iPad 3 tag in the head

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,8 @@ Apache License: v2.0. http://www.apache.org/licenses/LICENSE-2.0
 <!-- JavaScript -->
 <script src="js/modernizr-2.5.3-min.js"></script>
 
+<!-- For iPad 3 -->
+<!-- <link rel="apple-touch-icon-precomposed" sizes="144x144" href="img/h/apple-touch-icon-144x144-precomposed.png"> -->
 <!-- For iPhone 4 -->
 <!-- <link rel="apple-touch-icon-precomposed" sizes="114x114" href="img/h/apple-touch-icon.png"> -->
 <!-- For iPad 1-->


### PR DESCRIPTION
updated head for iPad 3 icon. Propose restructuring that way these icons are separated, m = medium, h = huge? Why not:

<!-- For iPad 5 -->

<link rel="apple-touch-icon-precomposed" sizes="144x144" href="img/apple-touch-icon-144x144-precomposed.png">

<!-- For iPhone 4 -->

<link rel="apple-touch-icon-precomposed" sizes="114x114" href="img/apple-touch-icon-114x114-precomposed.png">

<!-- For iPad 1-->

<link rel="apple-touch-icon-precomposed" sizes="72x72" href="img/apple-touch-icon-72x72-precomposed.png">

<!-- For iPhone 3G, iPod Touch and Android -->

<link rel="apple-touch-icon-precomposed" href="img/apple-touch-icon-57x57-precomposed.png">

<!-- For everything else -->

<link rel="shortcut icon" href="img/favicon.ico">
