### PR TITLE
https prefix for jQuery from CDN, and commented out GA snippet

### DIFF
--- a/320andup.html
+++ b/320andup.html
@@ -1,6 +1,6 @@
 <!doctype html>
 
-<!-- 
+<!--
 320 and Up by Andy Clarke
 Version: 3.0
 URL: http://stuffandnonsense.co.uk/projects/320andup/
@@ -639,17 +639,21 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 <small>&#8216;320 and Up&#8217; wouldn&#8217;t be possible without <a href="http://html5boilerplate.com/">HTML5 Boilerplate</a>, <a href="http://framelessgrid.com/">Frameless grid</a> and <a href="http://twitter.github.com/bootstrap/">Bootstrap</a>. Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. The Font Awesome webfont, CSS, and LESS files are licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</small>
 </footer>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="js/jquery-1.7.2.min.js"><\/script>')</script>
 
 <script src="js/plugins.js"></script>
 <script src="js/script.js"></script>
 <script src="js/helper.js"></script>
+
+<!-- Un-comment this block, and introduce your own GA Account ID in place of the UA-XXXXX-X placeholder, if you wish to use Google Analytics. Or remove the block completely if you don't
 <script>
 var _gaq=[["_setAccount","UA-XXXXX-X"],["_trackPageview"]];
 (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
 g.src=("https:"==location.protocol?"//ssl":"//www")+".google-analytics.com/ga.js";
 s.parentNode.insertBefore(g,s)}(document,"script"));
 </script>
+-->
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 
-<!-- 
+<!--
 320 and Up by Andy Clarke
 Version: 3.0
 URL: http://stuffandnonsense.co.uk/projects/320andup/
@@ -83,7 +83,7 @@ Apache License: v2.0. http://www.apache.org/licenses/LICENSE-2.0
 
 <p>I&#8217;m proud to say that &#8216;320 and Up&#8217; has been used by designers and developers all over the web. I&#8217;ve used versions of it on every website I&#8217;ve worked on since I wrote it. Small websites, medium-size websites and large websites including ISO, STV and UK Government websites that&#8217;ll launch this year.</p>
 
-<p>Along the way, &#8216;320 and Up&#8217; grown to include selected files and styles from Twitter&#8217;s Bootstrap as well as responsive design libraries and polyfills. It&#8217;s become my personal toolkit, somewhere I keep the files and styles that I use when I start every new project.</p> 
+<p>Along the way, &#8216;320 and Up&#8217; grown to include selected files and styles from Twitter&#8217;s Bootstrap as well as responsive design libraries and polyfills. It&#8217;s become my personal toolkit, somewhere I keep the files and styles that I use when I start every new project.</p>
 
 <h2 class="h3">&#8216;320 and Up&#8217; contains:</h2>
 
@@ -110,17 +110,21 @@ Apache License: v2.0. http://www.apache.org/licenses/LICENSE-2.0
 <small>&#8216;320 and Up&#8217; wouldn&#8217;t be possible without <a href="http://html5boilerplate.com/">HTML5 Boilerplate</a>, <a href="http://framelessgrid.com/">Frameless grid</a> and <a href="http://twitter.github.com/bootstrap/">Bootstrap</a>. Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. The Font Awesome webfont, CSS, and LESS files are licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</small>
 </footer>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="js/jquery-1.7.2.min.js"><\/script>')</script>
 
 <script src="js/plugins.js"></script>
 <script src="js/script.js"></script>
 <script src="js/helper.js"></script>
+
+<!-- Un-comment this block, and introduce your own GA Account ID in place of the UA-XXXXX-X placeholder, if you wish to use Google Analytics. Or remove the block completely if you don't
 <script>
 var _gaq=[["_setAccount","UA-XXXXX-X"],["_trackPageview"]];
 (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
 g.src=("https:"==location.protocol?"//ssl":"//www")+".google-analytics.com/ga.js";
 s.parentNode.insertBefore(g,s)}(document,"script"));
 </script>
+-->
+
 </body>
 </html>

--- a/less/upstarts/320andup-modules/example.html
+++ b/less/upstarts/320andup-modules/example.html
@@ -1,7 +1,7 @@
 <!doctype html>
 
-<!-- 
-320 and Up 
+<!--
+320 and Up
 Author: Andy Clarke (http://stuffandnonsense.co.uk)
 Author: Keith Clark (http://twitter.com/keithclarkcouk)
 Version: 3
@@ -151,17 +151,21 @@ License: http://creativecommons.org/licenses/MIT/
 <small>&#8216;320 and Up&#8217; wouldn&#8217;t be possible without <a href="http://html5boilerplate.com/">HTML5 Boilerplate</a>, <a href="http://framelessgrid.com/">Frameless grid</a> and <a href="http://twitter.github.com/bootstrap/">Bootstrap</a>. Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. The Font Awesome webfont, CSS, and LESS files are licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</small>
 </footer>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../../js/jquery-1.7.2.min.js"><\/script>')</script>
 
 <script src="../../../js/plugins.js"></script>
 <script src="../../../js/script.js"></script>
 <script src="../../../js/helper.js"></script>
+
+<!-- Un-comment this block, and introduce your own GA Account ID in place of the UA-XXXXX-X placeholder, if you wish to use Google Analytics. Or remove the block completely if you don't
 <script>
 var _gaq=[["_setAccount","UA-XXXXX-X"],["_trackPageview"]];
 (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
 g.src=("https:"==location.protocol?"//ssl":"//www")+".google-analytics.com/ga.js";
 s.parentNode.insertBefore(g,s)}(document,"script"));
 </script>
+-->
+
 </body>
 </html>

--- a/less/upstarts/320andup-modules/index.html
+++ b/less/upstarts/320andup-modules/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 
-<!-- 
-320 and Up 
+<!--
+320 and Up
 Author: Andy Clarke (http://stuffandnonsense.co.uk)
 Author: Keith Clark (http://twitter.com/keithclarkcouk)
 Version: 3
@@ -122,17 +122,21 @@ License: http://creativecommons.org/licenses/MIT/
 <small>&#8216;320 and Up&#8217; wouldn&#8217;t be possible without <a href="http://html5boilerplate.com/">HTML5 Boilerplate</a>, <a href="http://framelessgrid.com/">Frameless grid</a> and <a href="http://twitter.github.com/bootstrap/">Bootstrap</a>. Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. The Font Awesome webfont, CSS, and LESS files are licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</small>
 </footer>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../../js/jquery-1.7.2.min.js"><\/script>')</script>
 
 <script src="../../../js/plugins.js"></script>
 <script src="../../../js/script.js"></script>
 <script src="../../../js/helper.js"></script>
+
+<!-- Un-comment this block, and introduce your own GA Account ID in place of the UA-XXXXX-X placeholder, if you wish to use Google Analytics. Or remove the block completely if you don't
 <script>
 var _gaq=[["_setAccount","UA-XXXXX-X"],["_trackPageview"]];
 (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
 g.src=("https:"==location.protocol?"//ssl":"//www")+".google-analytics.com/ga.js";
 s.parentNode.insertBefore(g,s)}(document,"script"));
 </script>
+-->
+
 </body>
 </html>

--- a/less/upstarts/320andup-panels/index.html
+++ b/less/upstarts/320andup-panels/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 
-<!-- 
-320 and Up 
+<!--
+320 and Up
 Author: Andy Clarke (http://stuffandnonsense.co.uk)
 Author: Keith Clark (http://twitter.com/keithclarkcouk)
 Version: 3
@@ -202,17 +202,21 @@ License: http://creativecommons.org/licenses/MIT/
 <small>&#8216;320 and Up&#8217; wouldn&#8217;t be possible without <a href="http://html5boilerplate.com/">HTML5 Boilerplate</a>, <a href="http://framelessgrid.com/">Frameless grid</a> and <a href="http://twitter.github.com/bootstrap/">Bootstrap</a>. Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>. The Font Awesome webfont, CSS, and LESS files are licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.</small>
 </footer>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../../js/jquery-1.7.2.min.js"><\/script>')</script>
 
 <script src="../../../js/plugins.js"></script>
 <script src="../../../js/script.js"></script>
 <script src="../../../js/helper.js"></script>
+
+<!-- Un-comment this block, and introduce your own GA Account ID in place of the UA-XXXXX-X placeholder, if you wish to use Google Analytics. Or remove the block completely if you don't
 <script>
 var _gaq=[["_setAccount","UA-XXXXX-X"],["_trackPageview"]];
 (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
 g.src=("https:"==location.protocol?"//ssl":"//www")+".google-analytics.com/ga.js";
 s.parentNode.insertBefore(g,s)}(document,"script"));
 </script>
+-->
+
 </body>
 </html>


### PR DESCRIPTION
I've added the "https" prefix to the references to jQuery from google CDN (without it, you'd get an error when serving the pages on the file:// protocol)

I've also wrapped the GA snippets in comments, because they'd lead to errors until one enters their own GA ID.

Not sure if these are scenarios you are targeting, but they were the only two errors "out of the box" left for me. Hopefully a user can now grab the zip from github, unzip and open index.html and get no errors. HTH
