### PR TITLE
Added LTE IE8 SCSS File for Compiling Styles Independent of Media Queries

### DIFF
--- a/scss/lte-ie8.scss
+++ b/scss/lte-ie8.scss
@@ -1,0 +1,28 @@
+/* ============================================================
+
+320 and Up by Andy Clarke
+Version: 3.0
+URL: http://stuffandnonsense.co.uk/projects/320andup/
+Apache License: v2.0. http://www.apache.org/licenses/LICENSE-2.0
+
+============================================================ */
+
+// 1. ROOT 					==============================
+
+// Variables and mixins
+@import "variables";
+@import "mixins";
+
+//  2. SERVE LTE IE8 		==============================
+
+// 480px
+@import "480";
+
+// 600px
+@import "600";
+
+// 768px
+@import "768";
+
+// 992px
+@import "992";


### PR DESCRIPTION
added lte ie8 so lte ie8 users get served media queries up to 1024 without polyfills like respond.js

Using Respond.js to serve lte ie8 users media queries can cause unpredictable results. This method ensures lte ie8 users are getting served media queries up a level as determined by the author, default is 1024.

If accepted, needs to be added to the other pre-compiler directories as well.
