### PR TITLE
_buttons and _textures scss mixins updated 

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -30,7 +30,7 @@
   border: $buttonborderwidth $buttonborderstyle $buttonbordercolor {
     bottom-color: $buttonbottombordercolor;
   }
-  @include border-radius(4px);
+  @include rounded(4px);
   cursor: pointer;
   *margin-left: .3em;
 
@@ -131,7 +131,7 @@ input[type="submit"].btn:hover { border-color: $buttonbordercolor; }
 .btn-extlarge {
   padding: 11px 22px;
   @include font-size(21);
-  @include border-radius(4px);
+  @include rounded(4px);
 }
 
 .btn.btn-large {
@@ -145,7 +145,7 @@ input[type="submit"].btn:hover { border-color: $buttonbordercolor; }
   padding: 11px 22px;
   @include font-size(14);
   line-height: normal;
-  @include border-radius(4px);
+  @include rounded(4px);
 }
 
 .btn-small {
@@ -170,7 +170,7 @@ input[type="submit"].btn:hover { border-color: $buttonbordercolor; }
     position: relative;
     float: left;
     margin-left: -1px;
-    @include border-radius(0);
+    @include rounded(0);
 
     &:first-child {
       margin-left: 0;

--- a/scss/_texture.scss
+++ b/scss/_texture.scss
@@ -20,7 +20,7 @@
   padding: 8px 35px 8px 14px;
   background-color: $alertcolor;
   border: $alertborderwidth $alertborderstyle $alertbordercolor;
-  @include border-radius(2px);
+  @include rounded(2px);
   font-family: $basefont;
   @include font-size(14);
   color: $alerttext;
@@ -94,7 +94,7 @@
   white-space: nowrap;
   color: $badgecolor;
   background-color: $badgebackground;
-  @include border-radius(9px);
+  @include rounded(9px);
   @include transition(background-color .25s 0 linear);
 
   &:hover {
@@ -177,7 +177,7 @@
   margin-bottom: $baselineheight;
   background-color: $wellbackground;
   border: $wellborderwidth $wellborderstyle $wellbordercolor;
-  @include border-radius(4px);
+  @include rounded(4px);
   @include box-shadow(inset 0 1px $wellshadowblur $wellshadow);
 
   p:last-child { margin-bottom: 0; }
@@ -187,5 +187,5 @@
 
 .well-small {
   padding: 6px;
-  @include border-radius(2px);
+  @include rounded(2px);
 }


### PR DESCRIPTION
_buttons and _textures were using a mixin called border-radius which looks like it's been supersede by a mixin called rounded - this was causing wells and buttons to only have one rounded corner

fixes #57
