### PR TITLE
Added call to MBP.hideUrlBarOnLoad() to hide Address bar in iOS

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,1 @@
+MBP.hideUrlBarOnLoad(); 


### PR DESCRIPTION
Using 320 and up, I found that the address bar would not hide in iOS. I've added this code in script.js that resolved it, though unsure whether this is a 'good fix'.
