### PR TITLE
FIx translate3d mixins

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -156,11 +156,11 @@ transition : $transition; }
 transform : translate($x, $y); }
 
 @mixin translate3d($x: 0, $y: 0, $z: 0) {
--webkit-transform : translate($x, $y, $z);
--moz-transform : translate($x, $y, $z);
--ms-transform : translate($x, $y, $z);
--o-transform : translate($x, $y, $z);
-transform : translate($x, $y, $z); }
+-webkit-transform : translate3d($x, $y, $z);
+-moz-transform : translate3d($x, $y, $z);
+-ms-transform : translate3d($x, $y, $z);
+-o-transform : translate3d($x, $y, $z);
+transform : translate3d($x, $y, $z); }
 
 // 5. ELEMENTS 				==============================
 


### PR DESCRIPTION
the translate3d mixin mistakenly had only "translate" in it, spent bloody hours trying to figure out why my menus wouldn't navigate :) 

I corrected this mixin, changing them all to translate3d
